### PR TITLE
Standardizing page titles and other CSS/content tweaks

### DIFF
--- a/remedy/static/css/remedy.css
+++ b/remedy/static/css/remedy.css
@@ -27,7 +27,6 @@ a:hover, .btn-link:hover {
 
 h1 {
 	border-bottom-style: dashed;
-	padding-bottom: 4px; 
 	text-align: center;
 	font-size: 4em; 
 	color: #3c204d; 

--- a/remedy/static/css/remedy.css
+++ b/remedy/static/css/remedy.css
@@ -195,12 +195,6 @@ div.form-group {
 	background-size:100%; 
 }
 
-.mission {
-	font-size: 1em; 
-	color: #3c204d;
-	font-weight: bold; 
-}
-
 .bar {
 	color:#fff;
 	background-color: #3c204d;

--- a/remedy/static/css/remedy.css
+++ b/remedy/static/css/remedy.css
@@ -59,8 +59,6 @@ h5 {
 	font-size: 1.3em;
 }
 
-
-
 p {
 	font-size: 1.3em; 
 	width: 90%; 
@@ -109,7 +107,6 @@ dd {
 	margin-left: 40px; 
 	font-size: 1.4em;
 	line-height: .7em; 
-
 }
 
 .recently-added-category {
@@ -117,7 +114,6 @@ dd {
 	margin-left: 40px; 
 	font-style: italic;
 	font-size:1.1em;
-	
 }
 
 .recently-added-text {
@@ -132,7 +128,6 @@ dd {
 .simple-search {
 	font-size: 1em; 
 	margin-top: 15px; 
-
 }
 
 .form-remedy {
@@ -153,21 +148,11 @@ div.form-group {
 	border-radius: 8px;
 	background-color: #fff;
 	margin-left: 3px; 
- 
 }
 
 .search-btn:hover {
-   background: #393536;
-   color: #bdbcbc;
-}
-
-.content-temp {
-	margin-top: 8px; 
-	background: #fff;
-	font-size: 1em; 
-	padding: 15px;
-	color: #393536;
-	border-radius: 8px; 
+  background: #393536;
+  color: #bdbcbc;
 }
 
 .arrow-style {
@@ -211,7 +196,6 @@ div.form-group {
 
 .introduction {
 	text-align: center; 
-	
 	font-weight: bold; 
 }
 
@@ -247,7 +231,6 @@ div.form-group {
 
 	padding-right: 5%; 
 	margin-bottom: 20px; 
-
 }
 
 .nav-title {
@@ -275,9 +258,9 @@ div.form-group {
 
 .logo {
 	width: 50%; 
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .bottombar {
@@ -318,18 +301,18 @@ div.form-group {
 }
 
 .flip-img {
-    -moz-transform: scaleX(-1);
-    -o-transform: scaleX(-1);
-    -webkit-transform: scaleX(-1);
-    transform: scaleX(-1);
-    filter: FlipH;
-    -ms-filter: "FlipH";
+  -moz-transform: scaleX(-1);
+  -o-transform: scaleX(-1);
+  -webkit-transform: scaleX(-1);
+  transform: scaleX(-1);
+  filter: FlipH;
+  -ms-filter: "FlipH";
 }
 
 .content {
 	margin-left: auto;
-    margin-right: auto;
-    width: 90%; 
+  margin-right: auto;
+  width: 90%; 
 }
 
 .rad-ul {

--- a/remedy/static/css/remedy.css
+++ b/remedy/static/css/remedy.css
@@ -50,6 +50,11 @@ h3 {
 	font-weight: bold; 
 }
 
+h3 small {
+  color: #3D2E43; /* Pubple desaturated by 25% */
+  font-style: italic; 
+}
+
 h4 {
 	font-weight: bold; 
 }
@@ -71,6 +76,10 @@ dt {
 
 dd {
 	font-size: 1.2em; 
+}
+
+blockquote {
+  border-left-color: #3c204d;
 }
 
 .recently-added {

--- a/remedy/static/css/remedy.css
+++ b/remedy/static/css/remedy.css
@@ -42,6 +42,7 @@ h2 {
 	text-align: center; 
 	border-bottom: solid #3c204d; 
 	width: 90%; 
+	text-transform: uppercase;
 }
 
 h3 {

--- a/remedy/templates/404.html
+++ b/remedy/templates/404.html
@@ -2,7 +2,6 @@
 
 {% block title %}RAD Remedy - Page Not Found{% endblock %}
 {% block head_text %}Page Not Found{% endblock %}
-{% block head_blurb %}{% endblock %}
 
 {% block content %}
 

--- a/remedy/templates/500.html
+++ b/remedy/templates/500.html
@@ -2,7 +2,6 @@
 
 {% block title %}RAD Remedy - Server Error{% endblock %}
 {% block head_text %}Server Error{% endblock %}
-{% block head_blurb %}{% endblock %}
 
 {% block content %}
 

--- a/remedy/templates/about.html
+++ b/remedy/templates/about.html
@@ -5,65 +5,102 @@
 
 {% block content %}
 
-    <h2>Mission</h2>
-    <p>RAD’s Remedy's mission is to connect trans, gender non-conforming, intersex, and queer people to accurate, safe, respectful, and holistic care in order to improve individual and community health.</p>
+<h2>About RAD Remedy</h2>
 
-    <h2>Who We Are</h2>
-    <p>RAD Remedy is collectively operated via two teams (each in alphabetical order by first name – hover for bio). We operate virtually via Google Hangouts and our team members are from various locations across the country. We are based operationally in Chicago, Illinois and are a 501(c) (3) fiscally-sponsored organization:</p>
-    <h3>Team</h3>
-    <ul class="rad-ul list-unstyled">
-        <li>Allie Deford, Technical Director</li>
-        <li>Cate Sparkles, Lead Developer</li>
-        <li>Daniel Herrle, Design Director</li>
-        <li>Eliot Colin, Outreach Director</li>
-        <li>Rachel Hennessy, Operations Director</li>
-        <li>Riley Johnson, Executive Director</li>
-    </ul>
-    <h3>Board of Directors</h3>
-    <ul class="rad-ul list-unstyled">
-        <li>Andrea Zekis, Co-Chair</li>
-        <li>Bre Kidman</li>
-        <li>Chef Fresh Roberson, Co-Chair</li>
-        <li>Elayne Wylie</li>
-        <li>Hale Thompson</li>
-        <li>Lars Mackenzie</li>
-        <li>Noam Ostrander</li>
-        <li>Riley Johnson, Ex officio</li>
-    </ul>
+<h3>Mission</h3>
+<blockquote>
+    RAD Remedy's mission is to connect trans, gender non-conforming, intersex, 
+    and queer people to accurate, safe, respectful, and holistic care in order 
+    to improve individual and community health.
+</blockquote>
 
-    <h3>501(c)(3) Fiscal Sponsor</h3>
-    <p>FORGE, Inc. of Milwaukee, Wisconsin</p>
+<h3>Who We Are</h3>
+<p>
+    RAD Remedy is collectively operated via two units (each in alphabetical order by first name). 
+    We operate virtually via Google Hangouts and our team and board members are from various locations 
+    across the country. We are based operationally in Chicago, Illinois and are a 501(c) (3) 
+    fiscally-sponsored organization:
+</p>
 
-    <h3>History</h3> 
-    <p>RAD Remedy got its start during <a href="http://www.transhack.org/">Trans*H4ck</a> Chicago in March 2014. Through the collaborative processes that happen at hackathons, Eliot, Rachel, and Riley honed our initial idea in conversation with other attendees, and presented our wireframe and minimal viable product. The judges awarded our project with the top honors of the hack, resulting in $500 in seed money through Amazon Web Services. We determined that the best way forward would be by engaging in a needs assessment survey of both individuals and organizations, so we would know the needs and desires of many folks within our community and could build a tool that serves folks well. </p>
+<h4>Team</h4>
+<ul>
+    <li>Allie Deford, <em>Technical Director</em></li>
+    <li>Cate Sparkles, <em>Lead Developer</em></li>
+    <li>Daniel Herrle, <em>Design Director</em></li>
+    <li>Eliot Colin, <em>Co-Founder</em></li>
+    <li>Rachel Hennessy, <em>Director of Operations</em></li>
+    <li>Riley Johnson, <em>Executive Director</em></li>
+</ul>
 
-    <p>We presented at TransOhio and exhibited at Philly Trans Health Conference, meeting folks, sharing stories, and collecting many survey responses along the way. Since then, we’ve had many more responses via our web-based version of the survey, providing a clear understanding of what many folks need and how we can best go forward. Through these experiences, we also gained additional team members Allie, Cate, and Dan, and the current RAD Remedy collective was born.</p>
+<h4>Board of Directors</h4>
+<ul>
+    <li>Andrea Zekis, <em>Co-Chair</em></li>
+    <li>Bre Kidman</li>
+    <li>Chef Fresh Roberson, <em>Co-Chair</em></li>
+    <li>Elayne Wylie</li>
+    <li>Hale Thompson</li>
+    <li>Lars Mackenzie</li>
+    <li>Noam Ostrander</li>
+    <li>Riley Johnson, <em>Ex officio</em></li>
+</ul>
 
-    <p>On January 1, 2015, we seated our first-ever board of directors, with members hailing from many locations across the United States. Shortly thereafter, Andrea Zekis and Chef Fresh Roberson were selected by the board as Co-Chairs. In addition, we gained an additional twenty volunteers dedicated to data maintenance and curation.</p>
+<h4>501(c)(3) Fiscal Sponsor</h4>
+<p>
+    FORGE, Inc. of Milwaukee, Wisconsin
+</p>
 
-    <h3>Looking Forward</h3>
-    <p>
-        In a short time, RAD Remedy will develop RAD (Referral Aggregator Database), 
-        a comprehensive and nationally-collaborative database that uses the 
-        referral lists of trusted community organizations and 
-        the detailed reviews of folks like you.
-    </p>
-    <p>
-        In addition, we plan on unveiling a feature known as &quot;RAD Certified&quot;
-        where providers provide evidence of continuing education they've completed 
-        on topics related to our community, and in turn, we provide a special badge 
-        for them on the site and optimized search results for you.                  
-    </p>    
-    <p>
-        Other future plans include talking with the community about our rights 
-        in various environments and situations, translation of our site and database 
-        into as many languages as possible, and consulting services for providers' 
-        intake forms and other systems.
-    </p>
-    <p>
-        If you've got other great ideas or want to be a part of the action in some way, 
-        write to us at <a href="mailto:board@radremedy.org">board@radremedy.org</a>. 
-        We welcome questions and feedback there too. Thanks for your interest!
-    </p>
+<h3>History</h3>
+<p>
+    RAD Remedy got its start during <a href="http://www.transhack.org/" target="_blank">Trans*H4ck</a> 
+    Chicago in March 2014. Through the collaborative processes that happen at hackathons, 
+    Eliot, Rachel, and Riley honed our initial idea in conversation 
+    with other attendees, and presented our wireframe and minimal viable product. 
+    The judges awarded our project with the top honors of the hack, 
+    resulting in $500 in seed money through Amazon Web Services. 
+    We determined that the best way forward would be by engaging in 
+    a needs assessment survey of both individuals and organizations, 
+    so we would know the needs and desires of many folks within our 
+    community and could build a tool that serves folks well. 
+</p>
+<p>
+    We presented at TransOhio and exhibited at Philly Trans Health Conference, 
+    meeting folks, sharing stories, and collecting many survey responses along the way. 
+    Since then, we've had many more responses via our web-based version of the survey, 
+    providing a clear understanding of what many folks need and how we can best go forward. 
+    Through these experiences, we also gained additional team members Allie, Cate, and Dan, 
+    and the current RAD Remedy team was born.
+</p>
+<p>
+    On January 1, 2015, we seated our first-ever board of directors, 
+    with members hailing from many locations across the United States. 
+    Shortly thereafter, Andrea Zekis and Chef Fresh Roberson were selected by the board 
+    as Co-Chairs. In addition, we gained an additional twenty volunteers 
+    dedicated to data maintenance and curation.
+</p>
+
+<h3>Looking Forward</h3>
+<p>
+    In a short time, RAD Remedy will develop RAD (Referral Aggregator Database), 
+    a comprehensive and nationally-collaborative database that uses the 
+    referral lists of trusted community organizations and 
+    the detailed reviews of folks like you.
+</p>
+<p>
+    In addition, we plan on unveiling a feature known as &quot;RAD Certified&quot;
+    where providers provide evidence of continuing education they've completed 
+    on topics related to our community, and in turn, we provide a special badge 
+    for them on the site and optimized search results for you.                  
+</p>    
+<p>
+    Other future plans include talking with the community about our rights 
+    in various environments and situations, translation of our site and database 
+    into as many languages as possible, and consulting services for providers' 
+    intake forms and other systems.
+</p>
+<p>
+    If you've got other great ideas or want to be a part of the action in some way, 
+    write to us at <a href="mailto:board@radremedy.org">board@radremedy.org</a>. 
+    We welcome questions and feedback there too. Thanks for your interest!
+</p>
 
 {% endblock %}

--- a/remedy/templates/about.html
+++ b/remedy/templates/about.html
@@ -42,12 +42,28 @@
     <p>On January 1, 2015, we seated our first-ever board of directors, with members hailing from many locations across the United States. Shortly thereafter, Andrea Zekis and Chef Fresh Roberson were selected by the board as Co-Chairs. In addition, we gained an additional twenty volunteers dedicated to data maintenance and curation.</p>
 
     <h2 class="text-uppercase">Looking Forward</h2>
-    <p>In a short time, RAD Remedy will develop RAD (Referral Aggregator Database), a comprehensive and nationally-collaborative database that uses the referral lists of trusted community organizations and the detailed reviews of folks like you.
-    In addition, we plan on unveiling a feature known as “RAD Certified” where providers provide evidence of continuing education they’ve completed on topics related to our community, and in turn, we provide a special badge for them on the site and optimized search results for you.
+    <p>
+        In a short time, RAD Remedy will develop RAD (Referral Aggregator Database), 
+        a comprehensive and nationally-collaborative database that uses the 
+        referral lists of trusted community organizations and 
+        the detailed reviews of folks like you.
+    </p>
+    <p>
+        In addition, we plan on unveiling a feature known as &quot;RAD Certified&quot;
+        where providers provide evidence of continuing education they've completed 
+        on topics related to our community, and in turn, we provide a special badge 
+        for them on the site and optimized search results for you.                  
+    </p>    
+    <p>
+        Other future plans include talking with the community about our rights 
+        in various environments and situations, translation of our site and database 
+        into as many languages as possible, and consulting services for providers' 
+        intake forms and other systems.
+    </p>
+    <p>
+        If you've got other great ideas or want to be a part of the action in some way, 
+        write to us at <a href="mailto:board@radremedy.org">board@radremedy.org</a>. 
+        We welcome questions and feedback there too. Thanks for your interest!
+    </p>
 
-    Other future plans include talking with the community about our rights in various environments and situations, translation of our site and database into as many languages as possible, and consulting services for providers’ intake forms and other systems.
-
-    If you’ve got other great ideas or want to be a part of the action in some way, write to us at <a href="mailto:board@radremedy.org">board@radremedy.org</a>. We welcome questions and feedback there too. Thanks for your interest!</p>
-
-<br>
 {% endblock %}

--- a/remedy/templates/about.html
+++ b/remedy/templates/about.html
@@ -5,12 +5,12 @@
 
 {% block content %}
 
-    <h2 class="text-uppercase">Mission</h2>
+    <h2>Mission</h2>
     <p>RAD’s Remedy's mission is to connect trans, gender non-conforming, intersex, and queer people to accurate, safe, respectful, and holistic care in order to improve individual and community health.</p>
 
-    <h2 class="text-uppercase">Who We Are</h2>
-    <p>RAD Remedy is collectively operated via two teams (each in alphabetical order by first name – hover for bio). We operate virtually via Google Hangouts and our team members are from various locations across the country. We are based operationally in Chicago, Illinois and are a 501(c) (3) fiscally-sponsored organization: </p>
-    <h3 class="text-uppercase">Team</h3>
+    <h2>Who We Are</h2>
+    <p>RAD Remedy is collectively operated via two teams (each in alphabetical order by first name – hover for bio). We operate virtually via Google Hangouts and our team members are from various locations across the country. We are based operationally in Chicago, Illinois and are a 501(c) (3) fiscally-sponsored organization:</p>
+    <h3>Team</h3>
     <ul class="rad-ul list-unstyled">
         <li>Allie Deford, Technical Director</li>
         <li>Cate Sparkles, Lead Developer</li>
@@ -19,7 +19,7 @@
         <li>Rachel Hennessy, Operations Director</li>
         <li>Riley Johnson, Executive Director</li>
     </ul>
-    <h3 class="text-uppercase">Board of Directors</h3>
+    <h3>Board of Directors</h3>
     <ul class="rad-ul list-unstyled">
         <li>Andrea Zekis, Co-Chair</li>
         <li>Bre Kidman</li>
@@ -31,17 +31,17 @@
         <li>Riley Johnson, Ex officio</li>
     </ul>
 
-    <h3 class="text-uppercase">501(c)(3) Fiscal Sponsor</h3>
+    <h3>501(c)(3) Fiscal Sponsor</h3>
     <p>FORGE, Inc. of Milwaukee, Wisconsin</p>
 
-    <h2 class="text-uppercase">History</h3> 
+    <h3>History</h3> 
     <p>RAD Remedy got its start during <a href="http://www.transhack.org/">Trans*H4ck</a> Chicago in March 2014. Through the collaborative processes that happen at hackathons, Eliot, Rachel, and Riley honed our initial idea in conversation with other attendees, and presented our wireframe and minimal viable product. The judges awarded our project with the top honors of the hack, resulting in $500 in seed money through Amazon Web Services. We determined that the best way forward would be by engaging in a needs assessment survey of both individuals and organizations, so we would know the needs and desires of many folks within our community and could build a tool that serves folks well. </p>
 
     <p>We presented at TransOhio and exhibited at Philly Trans Health Conference, meeting folks, sharing stories, and collecting many survey responses along the way. Since then, we’ve had many more responses via our web-based version of the survey, providing a clear understanding of what many folks need and how we can best go forward. Through these experiences, we also gained additional team members Allie, Cate, and Dan, and the current RAD Remedy collective was born.</p>
 
     <p>On January 1, 2015, we seated our first-ever board of directors, with members hailing from many locations across the United States. Shortly thereafter, Andrea Zekis and Chef Fresh Roberson were selected by the board as Co-Chairs. In addition, we gained an additional twenty volunteers dedicated to data maintenance and curation.</p>
 
-    <h2 class="text-uppercase">Looking Forward</h2>
+    <h3>Looking Forward</h3>
     <p>
         In a short time, RAD Remedy will develop RAD (Referral Aggregator Database), 
         a comprehensive and nationally-collaborative database that uses the 

--- a/remedy/templates/about.html
+++ b/remedy/templates/about.html
@@ -1,10 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - About RAD Remedy{% endblock %}
+{% block title %}RAD Remedy - About RAD Remedy{% endblock %}
 {% block head_text %}About RAD Remedy{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
 
 {% block content %}
 

--- a/remedy/templates/base.html
+++ b/remedy/templates/base.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}Rad Remedy{% endblock %}</title>
+    <title>{% block title %}RAD Remedy{% endblock %}</title>
 
     <link href='http://fonts.googleapis.com/css?family=Open+Sans+Condensed:300|Lobster' rel='stylesheet' type='text/css'>
 
@@ -37,7 +37,6 @@
       </div>
       <div class="col-sm-6">
         <h1>{% block head_text %}{% endblock %}</h1>
-        <p class="mission">{% block head_blurb %}{% endblock %}</p>
       </div>
       <div class="col-sm-2">
       </div>

--- a/remedy/templates/change-password.html
+++ b/remedy/templates/change-password.html
@@ -2,9 +2,6 @@
 
 {% block title %}RAD Remedy - Change Password{% endblock %}
 {% block head_text %}Change Password{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
 
 {% block content %}
 <h2>Change Password</h2>

--- a/remedy/templates/contact.html
+++ b/remedy/templates/contact.html
@@ -1,10 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Contact RAD Team{% endblock %}
-{% block head_text %}Contact RAD Team{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
+{% block title %}RAD Remedy - Contact the RAD Team{% endblock %}
+{% block head_text %}Contact the RAD Team{% endblock %}
 
 {% block content %}
 

--- a/remedy/templates/contact.html
+++ b/remedy/templates/contact.html
@@ -7,8 +7,12 @@
 
     <h2 class="text-uppercase">Contact Us</h2>
     <ul class="rad-ul list-unstyled"> 
-        <li><span class="glyphicon glyphicon-envelope"></span> info@radremedy.org</li>
-        <li><span class="glyphicon glyphicon-earphone"></span> 414.939.4RAD (414.939.4723)</li>
+        <li><span class="glyphicon glyphicon-envelope"></span>&nbsp;
+        		<a href="mailto:info@radremedy.org">info@radremedy.org</a>
+        </li>
+        <li><span class="glyphicon glyphicon-earphone"></span>&nbsp;
+        	414.939.4RAD (414.939.4723)
+        </li>
         <li>Social Media: See links in the bottom banner</li>
     </ul>
 

--- a/remedy/templates/contact.html
+++ b/remedy/templates/contact.html
@@ -5,15 +5,15 @@
 
 {% block content %}
 
-    <h2 class="text-uppercase">Contact Us</h2>
-    <ul class="rad-ul list-unstyled"> 
-        <li><span class="glyphicon glyphicon-envelope"></span>&nbsp;
-        		<a href="mailto:info@radremedy.org">info@radremedy.org</a>
-        </li>
-        <li><span class="glyphicon glyphicon-earphone"></span>&nbsp;
-        	414.939.4RAD (414.939.4723)
-        </li>
-        <li>Social Media: See links in the bottom banner</li>
-    </ul>
+<h2>Contact Us</h2>
+<ul class="rad-ul list-unstyled"> 
+    <li><span class="glyphicon glyphicon-envelope"></span>&nbsp;
+    		<a href="mailto:info@radremedy.org">info@radremedy.org</a>
+    </li>
+    <li><span class="glyphicon glyphicon-earphone"></span>&nbsp;
+    	414.939.4RAD (414.939.4723)
+    </li>
+    <li>Social Media: See links in the bottom banner</li>
+</ul>
 
 {% endblock %}

--- a/remedy/templates/create-account-success.html
+++ b/remedy/templates/create-account-success.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Account Created{% endblock %}
+{% block title %}RAD Remedy - Account Created{% endblock %}
+{% block head_text %}Account Created{% endblock %}
 
 {% block content %}
 <h2>Account Created</h2>

--- a/remedy/templates/create-account.html
+++ b/remedy/templates/create-account.html
@@ -1,10 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Create Account{% endblock %}
+{% block title %}RAD Remedy - Create Account{% endblock %}
 {% block head_text %}Create Account{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
 
 {% block content %}
 

--- a/remedy/templates/delete-review.html
+++ b/remedy/templates/delete-review.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Delete Review{% endblock %}
+{% block title %}RAD Remedy - Delete Review{% endblock %}
+{% block head_text %}Delete Review{% endblock %}
 
 {% block content %}
 <div>

--- a/remedy/templates/donate.html
+++ b/remedy/templates/donate.html
@@ -1,10 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Donate{% endblock %}
+{% block title %}RAD Remedy - Donate{% endblock %}
 {% block head_text %}Donate{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
 
 {% block content %}
 

--- a/remedy/templates/donate.html
+++ b/remedy/templates/donate.html
@@ -5,23 +5,59 @@
 
 {% block content %}
 
-	<br>
-	<br>
-	<p>If you’d like to donate to RAD Remedy, you may do so it any of several ways:</p>
-	<ol> 
-		<li><a href="http://gratipay.com/radremedy">Gratipay</a> (good for small, recurring donations but not tax deductible)</li>
-		<li>PayPal (tax deductible and coming soon!)</li>
-		<li>Check/Money Order (tax deductible, sent to our fiscal sponsor): <br>
-			If you would like to mail checks or money orders, please do so to:<br> 
-			<br>
-			RAD Remedy<br>
-			c/o FORGE<br>
-			P.O. Box 1272<br>
-			Milwaukee, WI 53201<br>
-			<br>
-			Please make checks payable to FORGE and write RAD Remedy in the memo line.</li>
-	</ol>
-	<p>Thanks for your support!</p>
-
+<h2>Donating to RAD Remedy</h2>
+<p class="lead">
+		If you’d like to donate to RAD Remedy, you may do so in any of several ways:
+</p>
+<ul class="list-unstyled">
+	<li>
+		<h3>
+			<a href="http://gratipay.com/radremedy" target="_blank">
+				Gratipay
+			</a>
+			<small>
+				Good for small, recurring donations but not tax deductible
+			</small>
+		</h3>
+	</li>
+	<li>
+		<h3>
+			Paypal
+			<small>
+				Tax deductible
+			</small>
+		</h3>
+		<form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
+			<input type="hidden" name="cmd" value="_s-xclick">
+			<input type="hidden" name="hosted_button_id" value="WTUPXK2TQGSH2">
+			<input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif" 
+			border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+			<img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+		</form>
+	</li>
+	<li>
+		<h3>
+			Check/Money Order
+			<small>
+				Tax deductible, sent to our fiscal sponsor
+			</small>							
+		</h3>
+		<p>
+			If you would like to mail checks or money orders, please do so to:
+		</p>
+		<address>
+			RAD Remedy<br />
+			c/o FORGE<br />
+			P.O. Box 1272<br />
+			Milwaukee, WI 53201
+		</address>
+		<p>
+			Please make checks payable to FORGE and write RAD Remedy in the memo line.
+		</p>
+	</li>
+</ul>
+<p>
+	Thanks for your support!
+</p>
 
 {% endblock %}

--- a/remedy/templates/error-submitted.html
+++ b/remedy/templates/error-submitted.html
@@ -4,11 +4,10 @@
 {% block head_text %}Suggestion Submitted{% endblock %}
 
 {% block content %}
-<div class="content-temp">
-	<h2>Error Submitted</h2>
-	<p class="lead">
-		Thanks for letting us know!
-	</p>
-</div> 
+
+<h2>Error Submitted</h2>
+<p class="lead">
+	Thanks for letting us know!
+</p> 
 
 {% endblock %}

--- a/remedy/templates/error-submitted.html
+++ b/remedy/templates/error-submitted.html
@@ -1,10 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Error Submitted{% endblock %}
-{% block head_text %}Suggestion{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
+{% block title %}RAD Remedy - Suggestion Submitted{% endblock %}
+{% block head_text %}Suggestion Submitted{% endblock %}
 
 {% block content %}
 <div class="content-temp">

--- a/remedy/templates/error.html
+++ b/remedy/templates/error.html
@@ -4,30 +4,27 @@
 {% block head_text %}Submit a Correction{% endblock %}
 
 {% block content %}
-<div class="content-temp">
-	<h2>Contact</h2>
+<h2>Submit a Correction</h2>
 
-	<p class="lead">
-		Error in resource : {{resource.name}}
-	</p>
+<p class="lead">
+	Error in resource: {{resource.name}}
+</p>
 
-  {% for message in form.message.errors %}
-    <div class="flash">{{ message }}</div>
-  {% endfor %}
-	
-	  <form action="{{ url_for('remedy.submit_error', resource_id=resource.id) }}" method="post" role="form">
-    	{{ form.csrf_token }}
-			<div class="form-group">
-		    <div>
-		    	{{ form.message.label }}*
-		    </div>
-		    {{ form.message(class_="form-control form-remedy") }}
-			</div>
-	 		
-	 		<div class="form-group">
-			    {{ form.submit(class_="btn") }}
-			</div>
-	  </form>
-</div> 
+{% for message in form.message.errors %}
+<div class="flash">{{ message }}</div>
+{% endfor %}
 
+<form action="{{ url_for('remedy.submit_error', resource_id=resource.id) }}" method="post" role="form">
+	{{ form.csrf_token }}
+	<div class="form-group">
+    <div>
+    	{{ form.message.label }}*
+    </div>
+    {{ form.message(class_="form-control form-remedy") }}
+	</div>
+		
+		<div class="form-group">
+	    {{ form.submit(class_="btn") }}
+	</div>
+</form>
 {% endblock %}

--- a/remedy/templates/error.html
+++ b/remedy/templates/error.html
@@ -1,10 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Error{% endblock %}
-{% block head_text %}Submit Suggestion{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
+{% block title %}RAD Remedy - Submit a Correction{% endblock %}
+{% block head_text %}Submit a Correction{% endblock %}
 
 {% block content %}
 <div class="content-temp">

--- a/remedy/templates/find-provider.html
+++ b/remedy/templates/find-provider.html
@@ -1,10 +1,7 @@
 {% extends "base.html" %}
 
-{% block title %}Rad Remedy - Search{% endblock %}
-{% block head_text %}Search{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
+{% block title %}RAD Remedy - Search Providers{% endblock %}
+{% block head_text %}Search Providers{% endblock %}
 
 {% block head %}
 <link href="{{ url_for('static', filename='css/select2.min.css') }}" rel="stylesheet">

--- a/remedy/templates/find-provider.html
+++ b/remedy/templates/find-provider.html
@@ -9,7 +9,6 @@
 {% endblock %}
 
 {% block content %}
-<div class="content-temp">
 <h2>Find a Provider</h2>
 
 <form role="search" action="{{ url_for('remedy.resource_search') }}" method="GET">
@@ -110,8 +109,6 @@
 		{% endif %}
 	</section>
 </div>
-</div>
-
 {% endblock %}
 
 {% block scripts %}

--- a/remedy/templates/get-involved.html
+++ b/remedy/templates/get-involved.html
@@ -1,18 +1,18 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Contact RAD Team{% endblock %}
-{% block head_text %}Contact RAD Team{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
+{% block title %}RAD Remedy - Get Involved{% endblock %}
+{% block head_text %}Get Involved{% endblock %}
 
 {% block content %}
 
 <h2>Current Opportunities</h2>
 
 <h3>Volunteer</h3>
-<p>If you have mad skills of some sort (PR, data entry, baking, whatever!) and you’d like to volunteer, please fill out our <a href="http://goo.gl/forms/ZIjUHIhQZJ">volunteer form</a> and we’ll get in touch with you.
-Thanks for your interest!</p>
+<p>
+	If you have mad skills of some sort (PR, data entry, baking, whatever!) and you’d like to volunteer, 
+	please fill out our <a href="http://goo.gl/forms/ZIjUHIhQZJ">volunteer form</a> 
+	and we’ll get in touch with you. Thanks for your interest!
+</p>
 
 {% endblock %}
 

--- a/remedy/templates/index.html
+++ b/remedy/templates/index.html
@@ -1,10 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Home{% endblock %}
-{% block head_text %}Welcome!{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
+{% block title %}RAD Remedy - Home{% endblock %}
+{% block head_text %}RAD Remedy{% endblock %}
 
 {% block head %}
   <link href="{{ url_for('static', filename='css/select2.min.css') }}" rel="stylesheet">

--- a/remedy/templates/index.html
+++ b/remedy/templates/index.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content %}
-	<h2 class="text-uppercase">Search RAD's Database:</h2>
+	<h2>Search RAD's Database:</h2>
 	<div class="home-search text-center">
 		
 		<form class="search" role="search" action="{{ url_for('remedy.resource_search') }}" method="GET">
@@ -57,7 +57,7 @@
     </form>
 	</div>
 
-<h2 class="text-uppercase">Recently Added To RAD</h2>
+<h2>Recently Added To RAD</h2>
 <div class="als-container" id="recently-added-list">
 	<span class="als-prev"><img alt="left arrow" class="arrow-style flip-img" src="static/img/arrow.png" title="Previous"></span>
 	<div class="als-viewport">

--- a/remedy/templates/login.html
+++ b/remedy/templates/login.html
@@ -1,10 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Login{% endblock %}
+{% block title %}RAD Remedy - Login{% endblock %}
 {% block head_text %}Login{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
 
 {% block content %}
 <h2>Login</h2>

--- a/remedy/templates/password-reset.html
+++ b/remedy/templates/password-reset.html
@@ -2,9 +2,6 @@
 
 {% block title %}RAD Remedy - Reset Password{% endblock %}
 {% block head_text %}Reset Password{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
 
 {% block content %}
 <h2>Reset Password</h2>

--- a/remedy/templates/projects.html
+++ b/remedy/templates/projects.html
@@ -1,10 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Contact RAD Team{% endblock %}
-{% block head_text %}Contact RAD Team{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
+{% block title %}RAD Remedy - Projects{% endblock %}
+{% block head_text %}Projects{% endblock %}
 
 {% block content %}
 

--- a/remedy/templates/projects.html
+++ b/remedy/templates/projects.html
@@ -5,28 +5,62 @@
 
 {% block content %}
 
-<h2>Current Projects</h2>
-<dl> 
-<dt>RAD (Referral Aggregator Database)</dt>
-<dd>RAD is a comprehensive and nationally-collaborative database currently in development that uses the referral lists of trusted community organizations and the detailed reviews of folks like you so we all get better care.</dd>
-<dt>Social Media Compaigns</dt>
-<dd>From #selfcaresunday to #sexysaturday, we provide tips and resources for all aspects of the community and for your whole life. Follow us and have a RAD week!</dd> 
-<dt>Remedy on Demand</dt>
-<dd>We provide consulting services for providers of all kinds, examining systems, processes, and intake forms and making things easier for trans, gender non-conforming, intersex, and queer people to navigate.</dd>
-</dl>
-<h2>Coming Soon</h2>
+<h2>RAD Remedy Projects</h2>
+
+<h3>Current Projects</h3>
 <dl>
-<dt>Know Your Rights Guides</dt>
-<dd>We will provide programming and printable materials around folks’ rights and responsibilities in various settings (medical environments both urgent and non-urgent, police and court situations, and housing –just to name a few).</dd>
-<dt>Medical Guides</dt>
-<dd>We are partnering with radical illustrator <a href="http://www.isabellarotman.com/">Isabella Rotman</a> to release medical guides about self-exams, checkups, and hormone options. They will be made available for patients and providers alike, in print and online.</dd>
-<dt>Translation Project</dt>
-<dd>We will have the site, database, and materials translated into as many languages as possible.</dd> 
-<dt>RAD Certified</dt>
-<dd>We will have providers of various sorts provide evidence of continuing education they’ve completed on topics related to our community, and in turn, we provide a special badge for them on the database and optimized search results for you.</dd> 
+	<dt>RAD (Referral Aggregator Database)</dt>
+	<dd>
+		RAD is a comprehensive and nationally-collaborative database currently in development 
+		that uses the referral lists of trusted community organizations and 
+		the detailed reviews of folks like you so we all get better care.
+	</dd>
+	<dt>Social Media Campaigns</dt>
+	<dd>
+		From #selfcaresunday to #sexysaturday, we provide tips and resources 
+		for all aspects of the community and for your whole life. 
+		Follow us and have a RAD week!
+	</dd>
+	<dt>Remedy on Demand</dt>
+	<dd>
+		We provide consulting services for providers of all kinds, examining systems, processes, 
+		and intake forms and making things easier for trans, gender non-conforming, intersex, 
+		and queer people to navigate.
+	</dd>
 </dl>
 
-<h3>Got a project idea you’d like RAD Remedy to consider?  Tell us about it at <a href="mailto:board@radremedy.org">board@radremedy.org!</a></h3> 
-<br>
+<h3>Coming Soon</h3>
+<dl>
+	<dt>Know Your Rights Guides</dt>
+	<dd>
+		We will provide programming and printable materials around folks' rights and responsibilities 
+		in various settings (medical environments both urgent and non-urgent, police and court situations, 
+		and housing – just to name a few).
+	</dd>
+	<dt>Medical Guides</dt>
+	<dd>
+		We are partnering with radical illustrator 
+		<a href="http://www.isabellarotman.com/" target="_blank">Isabella Rotman</a> 
+		to release medical guides about self-exams, checkups, and hormone options. 
+		They will be made available for patients and providers alike, in print and online.
+	</dd>
+	<dt>Translation Project</dt>
+	<dd>
+		We will have the site, database, and materials translated into as many languages as possible.
+	</dd>
+	<dt>
+		RAD Certified
+	</dt>
+	<dd>
+		We will have providers of various sorts provide evidence of continuing education they've completed 
+		on topics related to our community, and in turn, we provide a special badge for them on 
+		the database and optimized search results for you.
+	</dd>
+</dl>
+
+<p class="lead">
+	Got a project idea you'd like RAD Remedy to consider? 
+	Tell us about it at <a href="mailto:board@radremedy.org">board@radremedy.org</a>!
+</p>
 
 {% endblock %}

--- a/remedy/templates/provider.html
+++ b/remedy/templates/provider.html
@@ -4,8 +4,6 @@
 {% block head_text %}Provider{% endblock %}
 
 {% block content %}
-<div class="content-temp">
-
 <h2>{{ provider.name }}</h2>
 
 {% if provider.organization %}
@@ -156,8 +154,5 @@
 {% endif %}
 
 {% include 'experiences.html' %}
-
-</div>
-
 
 {% endblock %}

--- a/remedy/templates/provider.html
+++ b/remedy/templates/provider.html
@@ -1,10 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - {{ provider.name }}{% endblock %}
+{% block title %}RAD Remedy - {{ provider.name }}{% endblock %}
 {% block head_text %}Provider{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
 
 {% block content %}
 <div class="content-temp">

--- a/remedy/templates/request-password-reset.html
+++ b/remedy/templates/request-password-reset.html
@@ -1,10 +1,7 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Request Password Reset{% endblock %}
+{% block title %}RAD Remedy - Request Password Reset{% endblock %}
 {% block head_text %}Request Password Reset{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
 
 {% block content %}
 <h2>Reset Password</h2>

--- a/remedy/templates/settings.html
+++ b/remedy/templates/settings.html
@@ -2,9 +2,6 @@
 
 {% block title %}RAD Remedy - My User Profile{% endblock %}
 {% block head_text %}My User Profile{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
 
 {% block content %}
 <h2>User Profile Settings</h2>

--- a/remedy/templates/settings.html
+++ b/remedy/templates/settings.html
@@ -6,7 +6,7 @@
 {% block content %}
 <h2>User Profile Settings</h2>
 
-<h3 class="text-uppercase">
+<h3>
 	My Profile
 </h3>
 <p class="lead">
@@ -32,7 +32,7 @@
 	</dl>
 </p>
 
-<h3 class="text-uppercase">
+<h3>
 	Change My Settings
 </h3>
 <form role="form" method="POST" action="{{ url_for('remedy.settings') }}">

--- a/remedy/templates/under-construction.html
+++ b/remedy/templates/under-construction.html
@@ -4,8 +4,8 @@
 {% block head_text %}Under Construction{% endblock %}
 
 {% block content %}
-<h2 class="text-uppercase">Under Construction</h2>
-<p>
+<h2>Under Construction</h2>
+<p class="lead">
 	As the site is still in development, some pages haven't been created yet, 
 	including this one! Feel free to continue browsing the rest of the site.
 </p>

--- a/remedy/templates/under-construction.html
+++ b/remedy/templates/under-construction.html
@@ -1,17 +1,17 @@
 {% extends 'base.html' %}
 
-{% block title %}Rad Remedy - Under Construction{% endblock %}
+{% block title %}RAD Remedy - Under Construction{% endblock %}
 {% block head_text %}Under Construction{% endblock %}
-{% block head_blurb %}This is where we would a nice blurb about what RAD is, who 
-            should use it, and what they might use it for. Also, this is a good 
-            spot for a short version of our mission statement!{% endblock %}
 
 {% block content %}
 <div class="content-temp">
-	<h2> UNDER CONSTRUCTION! </h2>
-	<p>As the site is still in development, some pages haven't been created yet, including this one! Feel free to continue browsing 
-		the rest of the site. </p>
-	<p>Questions? Free free to email us at <a href="mailto:info@radremedy.org">info@radremedy.org</a></p>
+	<h2 class="text-uppercase">Under Construction</h2>
+	<p>
+		As the site is still in development, some pages haven't been created yet, 
+		including this one! Feel free to continue browsing the rest of the site.
+	</p>
+	<p>
+		Questions? Free free to email us at <a href="mailto:info@radremedy.org">info@radremedy.org</a>.
+	</p>
 </div> 
-
 {% endblock %}

--- a/remedy/templates/under-construction.html
+++ b/remedy/templates/under-construction.html
@@ -4,14 +4,12 @@
 {% block head_text %}Under Construction{% endblock %}
 
 {% block content %}
-<div class="content-temp">
-	<h2 class="text-uppercase">Under Construction</h2>
-	<p>
-		As the site is still in development, some pages haven't been created yet, 
-		including this one! Feel free to continue browsing the rest of the site.
-	</p>
-	<p>
-		Questions? Free free to email us at <a href="mailto:info@radremedy.org">info@radremedy.org</a>.
-	</p>
-</div> 
+<h2 class="text-uppercase">Under Construction</h2>
+<p>
+	As the site is still in development, some pages haven't been created yet, 
+	including this one! Feel free to continue browsing the rest of the site.
+</p>
+<p>
+	Questions? Free free to email us at <a href="mailto:info@radremedy.org">info@radremedy.org</a>.
+</p>
 {% endblock %}


### PR DESCRIPTION
Closes #154.

The following changes were made:
- `head_blurb` is gone.
- All page titles now use "RAD Remedy". Certain titles were tweaked
- The `content-temp` CSS class, which was inconsistently-applied to certain pages, was removed.
- Instead of placing `text-uppercase` on all H2 elements, that's now defined in the styling for each H2 element in `remedy.css`.
- I removed the padding from H1 elements, since we don't have blurbs anymore. I was also able to remove the `mission` CSS class.
- Uses of `text-uppercase` on H3 elements was removed.
- The static content pages were updated to more closely match what's on http://radremedy.org/ right now.