### PR TITLE
Reset password using email

### DIFF
--- a/remedy/auth/forms.py
+++ b/remedy/auth/forms.py
@@ -99,47 +99,16 @@ class RequestPasswordResetForm(Form):
     A form to request a password reset.
 
     Fields on the form:
-        username
         email
-
-    Exactly one value must be provided for username/email.
     """
 
-    # Order matters for this - Optional needs to be the last item in the list.
-    username = StringField('Username', validators=[
-        Regexp('^[A-Za-z][A-Za-z0-9_.]*$', 0,
-               'Username must have only letters, numbers, dots or underscores'),
-        Optional()
+    email = StringField('Email', validators=[
+        DataRequired(), 
+        Email(), 
+        Length(1, 70)
     ])
 
-    email = StringField('Email', validators=[
-        Length(0, 70),
-        Email(), 
-        Optional()
-    ])    
-
     submit = SubmitField('Request Reset')
-
-    def validate(self):
-        """
-        Validates the form to ensure that exactly one field
-        out of username or email has been provided.
-        """
-        if not Form.validate(self):
-            return False
-
-        result = True
-        seen_username = (self.username.data and not self.username.data.isspace())
-        seen_email = (self.email.data and not self.email.data.isspace())
-
-        if not seen_username and not seen_email:
-            self.username.errors.append('Either a username or email address must be provided.')
-            result = False
-        elif seen_username and seen_email:
-            self.username.errors.append('Username and email address cannot both be provided.')
-            result = False
-
-        return result
 
 
 class PasswordResetForm(Form):

--- a/remedy/auth/forms.py
+++ b/remedy/auth/forms.py
@@ -100,15 +100,46 @@ class RequestPasswordResetForm(Form):
 
     Fields on the form:
         username
+        email
+
+    Exactly one value must be provided for username/email.
     """
 
+    # Order matters for this - Optional needs to be the last item in the list.
     username = StringField('Username', validators=[
-        DataRequired(), Length(1, message='Username has to be at least 1 character'),
         Regexp('^[A-Za-z][A-Za-z0-9_.]*$', 0,
-               'Username must have only letters, numbers, dots or underscores')
+               'Username must have only letters, numbers, dots or underscores'),
+        Optional()
     ])
 
+    email = StringField('Email', validators=[
+        Length(0, 70),
+        Email(), 
+        Optional()
+    ])    
+
     submit = SubmitField('Request Reset')
+
+    def validate(self):
+        """
+        Validates the form to ensure that exactly one field
+        out of username or email has been provided.
+        """
+        if not Form.validate(self):
+            return False
+
+        result = True
+        seen_username = (self.username.data and not self.username.data.isspace())
+        seen_email = (self.email.data and not self.email.data.isspace())
+
+        if not seen_username and not seen_email:
+            self.username.errors.append('Either a username or email address must be provided.')
+            result = False
+        elif seen_username and seen_email:
+            self.username.errors.append('Username and email address cannot both be provided.')
+            result = False
+
+        return result
 
 
 class PasswordResetForm(Form):

--- a/remedy/auth/user_auth.py
+++ b/remedy/auth/user_auth.py
@@ -236,27 +236,27 @@ def request_password_reset():
         if form.validate_on_submit():
 
             # Look up the user.
-            user = User.query.filter_by(username=form.username.data).first()
+            user = User.query.filter_by(email=form.email.data).first()
 
             # Make sure the user exists.
-            if user is None:
-                flash('Invalid username.')
-                return render_template('request-password-reset.html', form=form), 401
+            if user is not None:
 
-            # Make sure the user's email has been activated.
-            if user.email_activated == False:
-                flash('You must first activate your account. Check your email for the confirmation link.')
-                return login_redirect(), 401
+                # Make sure the user's email has been activated.
+                if user.email_activated == False:
+                    flash('You must first activate your account. Check your email for the confirmation link.')
+                    return login_redirect(), 401
 
-            # Generate a code and update the reset date.
-            user.email_code = str(uuid4())
-            user.reset_pass_date = datetime.utcnow()
+                # Generate a code and update the reset date.
+                user.email_code = str(uuid4())
+                user.reset_pass_date = datetime.utcnow()
 
-            # Save the user and send a confirmation email.
-            db.session.commit()
-            send_password_reset(user)
+                # Save the user and send a confirmation email.
+                db.session.commit()
+                send_password_reset(user)
 
-            # Flash a message and redirect the user to the 
+            # Flash a message and redirect the user to the login page
+            # Note: This is outside of the user check so that people can't abuse
+            # this system - it'll always indicate successful even if there isn't already an account.
             flash('Your password reset was successfully requested. Check your email for the link.')
             return login_redirect()
 

--- a/remedy/static/css/remedy.css
+++ b/remedy/static/css/remedy.css
@@ -15,12 +15,12 @@ body {
 	color: #393536;
 }
 
-a, .btn-link {
+a {
 	color:inherit;
 	border-bottom: 1px #3c204d dotted;
 }
 
-a:hover, .btn-link:hover {
+a:hover {
 	color: #e97bc4; 
 	text-decoration: none; 
 	border-bottom: 1px #e97bc4 solid;

--- a/remedy/templates/request-password-reset.html
+++ b/remedy/templates/request-password-reset.html
@@ -14,9 +14,18 @@
 
     {{ form.csrf_token }}
 
+		<p class="help-block">
+			Please provide either your username or email address.
+		</p>
+
     <div class="form-group">
         {{ form.username.label }}
         {{ form.username(class_="form-control form-remedy") }}
+    </div>
+
+    <div class="form-group">
+        {{ form.email.label }}
+        {{ form.email(class_="form-control form-remedy") }}
     </div>
 
     {{ form.submit(class_="btn") }}

--- a/remedy/templates/request-password-reset.html
+++ b/remedy/templates/request-password-reset.html
@@ -14,15 +14,6 @@
 
     {{ form.csrf_token }}
 
-		<p class="help-block">
-			Please provide either your username or email address.
-		</p>
-
-    <div class="form-group">
-        {{ form.username.label }}
-        {{ form.username(class_="form-control form-remedy") }}
-    </div>
-
     <div class="form-group">
         {{ form.email.label }}
         {{ form.email(class_="form-control form-remedy") }}


### PR DESCRIPTION
Closes #188.

I had a lot of hassle trying to get WTForms to work with either email *or* username, so I changed it to email in the interests of simplicity.

In the interests of preventing people from fishing for accounts by using a bunch of different email addresses, I made it pretend to work even if a nonexistent account is specified.