### PR TITLE
Add API key to Google Maps requests

### DIFF
--- a/remedy/admin_views/resourceview.py
+++ b/remedy/admin_views/resourceview.py
@@ -7,7 +7,7 @@ from admin_helpers import *
 
 from sqlalchemy import or_, not_, func
 
-from flask import redirect, flash, request, url_for
+from flask import current_app, redirect, flash, request, url_for
 from flask.ext.admin import BaseView, expose
 from flask.ext.admin.actions import action
 from flask.ext.admin.contrib.sqla import ModelView
@@ -187,7 +187,7 @@ class ResourceRequiringGeocodingView(ResourceView):
         if len(target_resources) > 0:
 
             # Set up the geocoder, and then try to geocode each resource
-            geocoder = Geocoder()
+            geocoder = Geocoder(api_key=current_app.config.get('MAPS_SERVER_KEY'))
 
             for resource in target_resources:
                 # Build a helpful message string to use for errors.

--- a/remedy/config.py
+++ b/remedy/config.py
@@ -35,6 +35,16 @@ class BaseConfig(object):
     SECRET_KEY = 'Our little secret'
 
     """
+    The key to use for server-side geocoding requests.
+    """
+    MAPS_SERVER_KEY = None
+
+    """
+    The key to use for client-side geocoding requests.
+    """
+    MAPS_CLIENT_KEY = None
+
+    """
     The base URL to the website.
     """
     BASE_URL = 'http://radremedy.org'
@@ -97,6 +107,13 @@ class ProductionConfig(BaseConfig):
     # Allow overriding the base URL
     if str(os.environ.get('RAD_BASE_URL')):
         BASE_URL = str(os.environ.get('RAD_BASE_URL'))
+
+    # Set the maps API keys
+    if str(os.environ.get('RAD_MAPS_SERVER_KEY')):
+        MAPS_SERVER_KEY = str(os.environ.get('RAD_MAPS_SERVER_KEY'))
+
+    if str(os.environ.get('RAD_MAPS_CLIENT_KEY')):
+        MAPS_CLIENT_KEY = str(os.environ.get('RAD_MAPS_CLIENT_KEY'))
 
     SQLALCHEMY_DATABASE_URI = 'mysql+mysqldb://{0}:{1}@{2}/{3}?charset=utf8&use_unicode=0'. \
         format(os.environ.get('RAD_DB_USERNAME'),

--- a/remedy/templates/macros.html
+++ b/remedy/templates/macros.html
@@ -58,7 +58,11 @@ and pagination structures).
 A macro for including the Google Maps JavaScript library.
 #}
 {% macro gmaps_script_include() %}
+{% if config.MAPS_CLIENT_KEY %}
+<script src="https://maps.googleapis.com/maps/api/js?v=3.exp&amp;libraries=places&amp;key={{ config.MAPS_CLIENT_KEY }}"></script>
+{% else %}
 <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&amp;libraries=places"></script>
+{% endif %}
 {% endmacro %}
 
 {#


### PR DESCRIPTION
Closes #200.

The keys are registered with the radremedy gmail account. The referrers are limited to radremedy.org and our staging site (for client-side stuff) and our WebFaction server IP (for the server-side geocoding). We'll have to update the allowed IPs for the latter once we get a fixed IP.

I briefly tested these using localhost as a referer and my public IP, which seemed to work OK, but then I removed them from the whitelist.

I had to add two separate keys, as there's one for all the client-side views and another for the server-side geocoding functionality. These are stored in the configs as `MAPS_CLIENT_KEY` and `MAPS_SERVER_KEY` respectively.

These default to None, which uses the same behavior as before. They are read from the `RAD_MAPS_CLIENT_KEY` and `RAD_MAPS_SERVER_KEY` environment variables.