### PR TITLE
Distance-based search ordering and front page optimizations

### DIFF
--- a/remedy/templates/settings.html
+++ b/remedy/templates/settings.html
@@ -62,7 +62,7 @@
 	      	By default, this location will be used when you search for resources.
 	      </p>
 
-	      {{ form.default_location(**{"class_": "form-control form-remedy", "aria-describedby": "default-location-help"}) }}
+	      {{ form.default_location(**{"class_": "form-control form-remedy", "aria-describedby": "default-location-help", "autocomplete": "off"}) }}
 
 	      {{ form.default_latitude }}
 	      {{ form.default_longitude }}


### PR DESCRIPTION
Closes #236 by sorting by the difference between the specified search location and the resource's location when distance-based searching is applied.

Closes #247 by using [Flask's SimpleCache](http://werkzeug.pocoo.org/docs/0.10/contrib/cache/#werkzeug.contrib.cache.SimpleCache). I also removed some stuff that was being unnecessarily loaded up for the front page (categories, recent reviews).