### PR TITLE
Bump up text length on reviews to 5000 characters

### DIFF
--- a/remedy/rad/forms.py
+++ b/remedy/rad/forms.py
@@ -74,9 +74,11 @@ class ReviewForm(Form):
     ])
 
     # this is the text field with more details
-    comments = TextAreaField('Comments', validators=[
+    comments = TextAreaField('Comments',
+        description='Leave any other comments about the provider here!\nThis is limited to 5,000 characters.', 
+        validators=[
         DataRequired(), 
-        Length(1, 2000)
+        Length(1, 5000)
     ])
 
     # the Resource been reviewed, this field is hidden

--- a/remedy/templates/add-review.html
+++ b/remedy/templates/add-review.html
@@ -93,9 +93,9 @@ N/A
   <div class="form-group">
     {{ form.comments.label }}
     <p id="comments-help" class="help-block">
-      Leave any other comments about the provider here!
+      {{ form.comments.description|nl2br }}
     </p>
-    {{ form.comments(**{"class_": "form-control form-remedy", "aria-describedby": "comments-help", "rows": "3"}) }}
+    {{ form.comments(**{"class_": "form-control form-remedy", "aria-describedby": "comments-help", "rows": "3", "minlength": "1", "maxlength": "5000", "required": "required"}) }}
   </div>
 
   {{ form.submit(class_="btn btn-primary btn-lg") }}


### PR DESCRIPTION
The overall review length is bumped up to 5000 characters. I also switched this over to use the `description` field on the form and added HTML5 attributes to help make it more clear to the end-user what's going on.