### PR TITLE
Add better handling of sole reviewers and pending reviews

### DIFF
--- a/remedy/remedyblueprint.py
+++ b/remedy/remedyblueprint.py
@@ -397,6 +397,8 @@ def resource(resource_id):
                 population_id of 0 and further aggregates will be provided
                 based on the current user's identities (if any aggregates
                 exist for those).
+            user_review_date: The date/time the current user has last
+                visibly reviewed the provider.
     """
     # Get the resource and all visible top-level reviews
     resource = resource_with_id(resource_id)
@@ -406,9 +408,18 @@ def resource(resource_id):
         filter(Review.visible == True). \
         all()
 
+    # Store the date of an existing review by the user
+    user_review_date = None
+
     # Ensure the filtered set of old reviews is
     # available on each review we're displaying
     for rev in reviews:
+
+        # See if the current user (if any) has reviewed this provider,
+        # and if so, store the created date of that
+        if current_user.is_authenticated() and rev.user_id == current_user.id:
+            user_review_date = rev.date_created
+
         # Filter down old to only the visible ones,
         # and add appropriate sorting
         rev.old_reviews_filtered = rev.old_reviews. \
@@ -439,7 +450,8 @@ def resource(resource_id):
     return render_template('provider.html', 
         provider=resource,
         reviews=reviews,
-        aggregateratings=aggregate_ratings)
+        aggregateratings=aggregate_ratings,
+        user_review_date=user_review_date)
 
 
 @remedy.route('/find-provider/', defaults={'page': 1})

--- a/remedy/templates/provider.html
+++ b/remedy/templates/provider.html
@@ -278,7 +278,9 @@
       </h4>
       {%- if user_review_pending %}
       <p class="text-muted">
-        These ratings are calculated periodically and your review hasn't been included yet.
+        <small>
+          These ratings are calculated periodically and your review hasn't been included yet.
+        </small>
       </p>
       {%- endif %}
       {# We can assume that we won't have identity-specific aggregates

--- a/remedy/templates/provider.html
+++ b/remedy/templates/provider.html
@@ -265,7 +265,7 @@
     </div>
   </div>
 
-  {% if aggregateratings|count > 0 or user_review_date != None %}
+  {% if overall_aggregate or user_review_pending %}
   <div class="row">
     <div class="col-xs-12 col-sm-10 col-md-8 col-lg-8">
       <h4>
@@ -276,45 +276,20 @@
           Calculated every 10 minutes
         </small>
       </h4>
-      {%- if aggregateratings|count == 0 %}
-      <p class="text-muted">
-        These ratings are calculated periodically and your review hasn't been included yet.
-      </p>
-      {% else %}
-      {%- with overallaggregate = aggregateratings|rejectattr("population_id")|first %}
-      {#
-        If we have an overall aggregate and the user's already reviewed the provider,
-        set user_review_pending if the last-reviewed date/time is before the date/time
-        the user made the review (meaning their rating isn't included yet).
-      #}
-      {%- if overallaggregate and user_review_date and overallaggregate.last_reviewed < user_review_date %}
-        {%- set user_review_pending = True %}
-      {%- else %}
-        {%- set user_review_pending = False %}
-      {%- endif %}
       {%- if user_review_pending %}
       <p class="text-muted">
         These ratings are calculated periodically and your review hasn't been included yet.
       </p>
       {%- endif %}
+      {# We can assume that we won't have identity-specific aggregates
+        without an overall aggregate as well. #}
+      {%- if overall_aggregate %}
       <div class="list-group">
-      {%- if overallaggregate %}
-      {{ aggregate_block('Overall', overallaggregate) }}
-      {%- endif %}
-      {%- for agg in aggregateratings|selectattr("population_id")|sort(attribute="num_ratings", reverse=True) %}
-      {#-
-        We only want to show the aggregate per-population ratings if
-        one of the following things is true:
-        - More than just one person from the population has left a review.
-        - The user has not left a review.
-        - The user has left a review, but it's not included yet.
-      #}
-      {% if agg.num_ratings > 1 or user_review_date == None or user_review_pending == True %}
+      {{ aggregate_block('Overall', overall_aggregate) }}
+      {%- for agg in identity_aggregates %}
       {{ aggregate_block(agg.population.name, agg) }}
-      {%- endif %}
       {%- endfor %}
-      </div> {#- Close off list-group #}
-      {%- endwith %}
+      </div>
       {%- endif %}
     </div>
   </div>

--- a/remedy/templates/provider.html
+++ b/remedy/templates/provider.html
@@ -265,7 +265,7 @@
     </div>
   </div>
 
-  {% if aggregateratings|count > 0 %}
+  {% if aggregateratings|count > 0 or user_review_date != None %}
   <div class="row">
     <div class="col-xs-12 col-sm-10 col-md-8 col-lg-8">
       <h4>
@@ -276,6 +276,11 @@
           Calculated every 10 minutes
         </small>
       </h4>
+      {%- if aggregateratings|count == 0 %}
+      <p class="text-muted">
+        These ratings are calculated periodically and your review hasn't been included yet.
+      </p>
+      {% else %}
       {%- with overallaggregate = aggregateratings|rejectattr("population_id")|first %}
       {#
         If we have an overall aggregate and the user's already reviewed the provider,
@@ -288,7 +293,7 @@
         {%- set user_review_pending = False %}
       {%- endif %}
       {%- if user_review_pending %}
-      <p class="text-info">
+      <p class="text-muted">
         These ratings are calculated periodically and your review hasn't been included yet.
       </p>
       {%- endif %}
@@ -297,7 +302,7 @@
       {{ aggregate_block('Overall', overallaggregate) }}
       {%- endif %}
       {%- for agg in aggregateratings|selectattr("population_id")|sort(attribute="num_ratings", reverse=True) %}
-      {#
+      {#-
         We only want to show the aggregate per-population ratings if
         one of the following things is true:
         - More than just one person from the population has left a review.
@@ -308,8 +313,9 @@
       {{ aggregate_block(agg.population.name, agg) }}
       {%- endif %}
       {%- endfor %}
+      </div> {#- Close off list-group #}
       {%- endwith %}
-      </div>
+      {%- endif %}
     </div>
   </div>
   {% endif %}

--- a/remedy/templates/provider.html
+++ b/remedy/templates/provider.html
@@ -276,15 +276,39 @@
           Calculated every 10 minutes
         </small>
       </h4>
-      <div class="list-group">
       {%- with overallaggregate = aggregateratings|rejectattr("population_id")|first %}
-        {%- if overallaggregate %}
-        {{ aggregate_block('Overall', overallaggregate) }}
-        {%- endif %}
-      {%- endwith %}
+      {#
+        If we have an overall aggregate and the user's already reviewed the provider,
+        set user_review_pending if the last-reviewed date/time is before the date/time
+        the user made the review (meaning their rating isn't included yet).
+      #}
+      {%- if overallaggregate and user_review_date and overallaggregate.last_reviewed < user_review_date %}
+        {%- set user_review_pending = True %}
+      {%- else %}
+        {%- set user_review_pending = False %}
+      {%- endif %}
+      {%- if user_review_pending %}
+      <p class="text-info">
+        These ratings are calculated periodically and your review hasn't been included yet.
+      </p>
+      {%- endif %}
+      <div class="list-group">
+      {%- if overallaggregate %}
+      {{ aggregate_block('Overall', overallaggregate) }}
+      {%- endif %}
       {%- for agg in aggregateratings|selectattr("population_id")|sort(attribute="num_ratings", reverse=True) %}
+      {#
+        We only want to show the aggregate per-population ratings if
+        one of the following things is true:
+        - More than just one person from the population has left a review.
+        - The user has not left a review.
+        - The user has left a review, but it's not included yet.
+      #}
+      {% if agg.num_ratings > 1 or user_review_date == None or user_review_pending == True %}
       {{ aggregate_block(agg.population.name, agg) }}
+      {%- endif %}
       {%- endfor %}
+      {%- endwith %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #281.

First of all, if I'm the only reviewer of a resource, I only see the top-level ratings instead of a list of all my identities with one review:
![only-reviewer](https://cloud.githubusercontent.com/assets/8010294/9287480/a85458e2-42e4-11e5-8d3b-743d9dbca042.PNG)

However, if there are other people who have reviewed a resource, I see all of the other identities that have at least one other reviewer - I have an identity unique to myself, which is omitted from this list:
![other-reviewers](https://cloud.githubusercontent.com/assets/8010294/9287485/024c6fce-42e5-11e5-90d1-51e381fdc82d.PNG)

In the event that there are ratings but my recent review isn't included in them, I see a special message:
![pending-review-notice](https://cloud.githubusercontent.com/assets/8010294/9287487/14c96f3a-42e5-11e5-8189-2b9c0243d354.PNG)

Similarly, there's a message if I'm the first person to review it and the aggregates haven't been calculated yet:
![pending-review-noscores](https://cloud.githubusercontent.com/assets/8010294/9287486/14b7657e-42e5-11e5-8650-e04c8f38dd01.PNG)

The appropriate MVC action calculates the date of my last visible review and provides that to the template as `user_review_date` and it all goes from there.