### PR TITLE
Add HTML5 input attributes

### DIFF
--- a/remedy/templates/add-provider.html
+++ b/remedy/templates/add-provider.html
@@ -40,8 +40,8 @@
   </h3>
 
   {{ macros.form_group(form.address) }}
-  {{ macros.form_group(form.phone_number) }}
-  {{ macros.form_group(form.fax_number) }}
+  {{ macros.form_group(form.phone_number, type='tel') }}
+  {{ macros.form_group(form.fax_number, type='tel') }}
   {{ macros.form_group(form.email) }}
   {{ macros.form_group(form.website) }}
 
@@ -67,7 +67,7 @@
     Other Information
   </h3>
 
-  {{ macros.form_group(form.npi) }}
+  {{ macros.form_group(form.npi, inputmode='numeric') }}
   {{ macros.form_group(form.other_notes) }}
 
   <hr />

--- a/remedy/templates/change-password.html
+++ b/remedy/templates/change-password.html
@@ -13,9 +13,9 @@
 <form role="form" method="POST" action="{{ url_for('auth.change_password') }}">
     {{ form.csrf_token }}
 
-    {{ macros.form_group(form.currentpassword) }}
-    {{ macros.form_group(form.password) }}
-    {{ macros.form_group(form.password2) }}
+    {{ macros.form_group(form.currentpassword, autocomplete='current-password') }}
+    {{ macros.form_group(form.password, autocomplete='new-password') }}
+    {{ macros.form_group(form.password2, autocomplete='new-password') }}
 
     {{ form.submit(class_="btn btn-primary") }}
 </form>

--- a/remedy/templates/create-account.html
+++ b/remedy/templates/create-account.html
@@ -28,7 +28,7 @@
     {{ form.csrf_token }}
 
     {{ macros.form_group(form.username) }}
-    {{ macros.form_group(form.display_name) }}
+    {{ macros.form_group(form.display_name, autocomplete='nickname') }}
 
 {% if form.populations.choices %}
     {{ macros.form_group(form.populations, **{"data-nounplural": "identities", "rows": "6"}) }}
@@ -36,8 +36,8 @@
   
     {{ macros.form_group(form.email) }}
 
-    {{ macros.form_group(form.password) }}
-    {{ macros.form_group(form.password2) }}
+    {{ macros.form_group(form.password, autocomplete='new-password') }}
+    {{ macros.form_group(form.password2, autocomplete='new-password') }}
 
     <div class="checkbox">
       <label>

--- a/remedy/templates/login.html
+++ b/remedy/templates/login.html
@@ -18,6 +18,13 @@
     {{ macros.form_group(form.password, autocomplete='current-password') }}
 
     <p class="help-block">
+        Don't have an account?
+        <a href="{{ url_for('auth.sign_up') }}">
+            Sign up here.
+        </a>
+    </p>
+
+    <p class="help-block">
         Forgot your password?
         <a href="{{ url_for('auth.request_password_reset') }}">
             Request a reset.

--- a/remedy/templates/login.html
+++ b/remedy/templates/login.html
@@ -14,8 +14,8 @@
 
     {{ form.csrf_token }}
 
-    {{ macros.form_group(form.username) }}
-    {{ macros.form_group(form.password) }}
+    {{ macros.form_group(form.username, autocomplete='username') }}
+    {{ macros.form_group(form.password, autocomplete='current-password') }}
 
     <p class="help-block">
         Forgot your password?

--- a/remedy/templates/password-reset.html
+++ b/remedy/templates/password-reset.html
@@ -13,8 +13,8 @@
 <form role="form" method="POST" action="{{ url_for('auth.reset_password', code=code) }}">
     {{ form.csrf_token }}
 
-    {{ macros.form_group(form.password) }}
-    {{ macros.form_group(form.password2) }}
+    {{ macros.form_group(form.password, autocomplete='new-password') }}
+    {{ macros.form_group(form.password2, autocomplete='new-password') }}
 
     {{ form.submit(class_="btn btn-primary") }}
 </form>

--- a/remedy/templates/settings.html
+++ b/remedy/templates/settings.html
@@ -43,7 +43,7 @@
 <form role="form" method="POST" action="{{ url_for('remedy.settings') }}">
 	{{ form.csrf_token }}
 
-	{{ macros.form_group(form.display_name) }}
+	{{ macros.form_group(form.display_name, autocomplete='nickname') }}
 	{{ macros.form_group(form.email) }}
 
 	<div class="form-group">


### PR DESCRIPTION
Closes #270. Most of the work was accomplished with the `form_group` macro/`get_field_args` method added in #298, but I did make the following additional changes:

- Username fields are flagged with an `autocomplete` value of `username`.
- Display Name fields are flagged with an `autocomplete` value of `nickname`.
- Current password fields are flagged with an `autocomplete` value of `current-password`.
- New password fields are flagged with an `autocomplete` value of `new-password`.

Specifically on the provider page:
- The phone number and fax number fields use an input type of `tel`.
- The NPI field is flagged with an `inputmode` of `numeric`.

In addition, while I was at it, I added a link to the signup page from the login screen.