### PR TITLE
Issue 320 geocoding locations

### DIFF
--- a/remedy/admin_views/admin_helpers.py
+++ b/remedy/admin_views/admin_helpers.py
@@ -189,6 +189,8 @@ resource_column_descriptions = {
         '(By Appointment Only); Thurs-Sat - 10:30 am - 7 pm ' +
         '(Appointments and Walk-ins); Sun - Closed',
     'source': 'The source of the resource\'s information.',
+    'location': 'The short location of the resource. Typically set by ' +
+        'geocoding, but can be customized/fixed as needed.',
     'notes':
         'Administrative notes for the resource, not visible to end users.',
     'advisory_notes':

--- a/remedy/rad/geocoder.py
+++ b/remedy/rad/geocoder.py
@@ -25,7 +25,7 @@ class Geocoder:
         Returns:
             The specified address component, or None if it does not exist.
         """
-        if key in addr_comp[key] and \
+        if key in addr_comp and \
                 len(addr_comp[key]) > 0 and \
                 not addr_comp[key].isspace():
             return addr_comp[key]

--- a/remedy/templates/admin/resource_create.html
+++ b/remedy/templates/admin/resource_create.html
@@ -9,5 +9,4 @@
     {{ macros.gmaps_script(true, 'address', 'latitude', 'longitude', 'location') }}
     {{ macros.hide_control_group('latitude') }}
     {{ macros.hide_control_group('longitude') }}
-    {{ macros.hide_control_group('location') }}
 {% endblock %}

--- a/remedy/templates/admin/resource_edit.html
+++ b/remedy/templates/admin/resource_edit.html
@@ -9,5 +9,4 @@
     {{ macros.gmaps_script(true, 'address', 'latitude', 'longitude', 'location') }}
     {{ macros.hide_control_group('latitude') }}
     {{ macros.hide_control_group('longitude') }}
-    {{ macros.hide_control_group('location') }}
 {% endblock %}

--- a/remedy/templates/admin/submitted_resource_edit.html
+++ b/remedy/templates/admin/submitted_resource_edit.html
@@ -47,7 +47,6 @@
 {{ macros.gmaps_script(true, 'address', 'latitude', 'longitude', 'location') }}
 {{ macros.hide_control_group('latitude') }}
 {{ macros.hide_control_group('longitude') }}
-{{ macros.hide_control_group('location') }}
 <script type="text/javascript">
 	// Make the cancel button use btn-default
 	$('a.btn-danger').removeClass('btn-danger').addClass('btn-default');


### PR DESCRIPTION
Closes #320.

It appears that the check within individual `address_components` for `short_name` or `long_name` did not work appropriately. This was likely a flake8 change.

To also help customize/fix existing data, the internal "Location" field is now editable with explanatory text.