### PR TITLE
Scroll to results on save and fix typeahead in Chrome

### DIFF
--- a/remedy/remedyblueprint.py
+++ b/remedy/remedyblueprint.py
@@ -56,7 +56,10 @@ def get_json_response(data):
     # TODO: Remove this once we're on flask v0.11
     # as we can just use jsonify then. We need to
     # use this to return simple arrays in the mean time.
-    return Response(dumps(data), 'application/json')
+    return Response(
+        dumps(data),
+        status=200,
+        mimetype='application/json')
 
 
 def get_paged_data(data, page, page_size=PER_PAGE):

--- a/remedy/templates/base.html
+++ b/remedy/templates/base.html
@@ -246,17 +246,17 @@
     window.Remedy.geoLocationButton('quick-loc-lookup', 'quick-addr', 'quick-lat', 'quick-long');
     $('.search-typeahead').typeahead({
       source: function(query, process) {
-        $.ajax({
+        var request =$.ajax({
           url: '/search-suggest/' + encodeURIComponent(query),
           accepts: 'application/json',
-          dataType: 'json',
-          success: function(results) {
-            process(results);
-          },
-          error: function() {
-            process([]);
-          }
+          dataType: 'json'
         });
+        request.done(function(results) {
+          process(results);
+        });
+        request.fail(function(jqXHR, textStatus) {
+          process([]);
+        })
       }
     }).attr('autocomplete', 'off');
   </script>

--- a/remedy/templates/base.html
+++ b/remedy/templates/base.html
@@ -56,7 +56,7 @@
       </div><!--
       --><div class="col-md-6 col-sm-12 simple-search-col">
         <form class="simple-search" role="search"
-          action="{{ url_for('remedy.resource_search') }}" method="GET">
+          action="{{ url_for('remedy.resource_search') }}#results" method="GET">
           <div class="form-group">
             <label for="quick-search" class="control-label">
               Find
@@ -133,7 +133,7 @@
           <li><a href="{{ url_for('remedy.how_to_use') }}">How to Use RAD</a></li>
           #}
           <li class="nav-button-highlight">
-            <a href="{{ url_for('remedy.resource_search', autofill='1') }}">
+            <a href="{{ url_for('remedy.resource_search', autofill='1') }}#results">
               Find Resources <em>(Beta!)</em>
             </a>
           </li>
@@ -161,7 +161,7 @@
               {#
               <li><a href="{{ url_for('remedy.how_to_use') }}">How to Use RAD</a></li>
               #}
-              <li><a href="{{ url_for('remedy.resource_search', autofill='1') }}">Find Resources <em>(Beta!)</em></a></li>
+              <li><a href="{{ url_for('remedy.resource_search', autofill='1') }}#results">Find Resources <em>(Beta!)</em></a></li>
               <li><a href="{{ url_for('remedy.about') }}">About RAD Remedy</a></li>
               <li><a href="{{ url_for('remedy.about_the_beta') }}">About the RAD Beta Launch</a></li>
               <li><a href="{{ url_for('remedy.projects') }}">RAD Projects</a></li>

--- a/remedy/templates/find-provider.html
+++ b/remedy/templates/find-provider.html
@@ -10,9 +10,19 @@
 <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
 <meta http-equiv="Pragma" content="no-cache">
 <meta http-equiv="Expires" content="0">
+<style type="text/css">
+a.anchor {
+  display: block; 
+  position: relative; 
+  top: -100px; 
+  visibility: hidden;
+}
+</style>
 {% endblock %}
 
 {% block content %}
+<a id="search-options" class="anchor"></a>
+
 <h2>Find a Provider <small>Beta!</small></h2>
 
 <div class="alert alert-info">
@@ -34,7 +44,7 @@
   </div>
 </div>
 
-<form role="search" action="{{ url_for('remedy.resource_search') }}" method="GET">
+<form role="search" action="{{ url_for('remedy.resource_search') }}#results" method="GET">
   <div class="form-group">
     <label for="text-search" class="sr-only control-label">
       Search
@@ -137,6 +147,8 @@
   </button>
 </form>
 
+<a id="results" class="anchor"></a>
+
 <div>
   <section>
     <h2>
@@ -154,7 +166,7 @@
     </h2>
     {% if not has_params %}
     <p class="alert alert-info">
-      Enter your search criteria above.
+      Enter <a href="#search-options">your search criteria above</a>.
       {% if logged_in() %}
       To default a location for all of your searches, update your <a href="{{ url_for('remedy.settings') }}" class="alert-link">user settings</a>.
       {% endif %}


### PR DESCRIPTION
Closes #336.

Works as expected. I also noticed that the typeahead wasn't working in Chrome due to the lack of an appropriate status code and content type and fixed that.